### PR TITLE
bugfix: removes max height in task expanded view to fix button cut off

### DIFF
--- a/frontend/src/components/task-list-item.tsx
+++ b/frontend/src/components/task-list-item.tsx
@@ -136,7 +136,7 @@ export function TaskListItem({
       <div
         className={cn(
           "border-t border-border overflow-hidden transition-all duration-300 ease-in-out",
-          isExpanded ? "max-h-[500px] opacity-100" : "max-h-0 opacity-0"
+          isExpanded ? "opacity-100" : "max-h-0 opacity-0"
         )}
       >
         <div className="p-4 space-y-3 text-left">


### PR DESCRIPTION
No need for max height now that the task description is truncated! 