### PR TITLE
bugfix: styling on Goals card in Growth view

### DIFF
--- a/frontend/src/pages/Growth/GrowthMenuView.tsx
+++ b/frontend/src/pages/Growth/GrowthMenuView.tsx
@@ -30,7 +30,7 @@ export const GrowthMenuView: React.FC<GrowthMenuViewProps> = ({
           Track your practice over time.
         </p>
       </Section>
-      <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+      <div className="grid grid-cols-1 md:grid-cols-3 gap-4 pb-4 md:pb-0">
         <Card className="p-6 text-center flex flex-col items-center justify-between">
           <CardTitle className="text-lg font-semibold mb-2">
             Total Practice Time
@@ -64,7 +64,7 @@ export const GrowthMenuView: React.FC<GrowthMenuViewProps> = ({
             View Chronological
           </Button>
         </Card>
-        <Card className="p-6 text-center flex flex-col mb-4 items-center justify-between">
+        <Card className="p-6 text-center flex flex-col items-center justify-between">
           <CardTitle className="text-lg font-semibold mb-2">
             Active Goals
           </CardTitle>


### PR DESCRIPTION
Previously I added margin to the bottom of the card so that it wouldn't be flush with the bottom of the screen on mobile. However that cut into the size of the card, so now using padding