### PR TITLE
bugfix: route to About on login

### DIFF
--- a/frontend/src/components/layout/TopBar.test.tsx
+++ b/frontend/src/components/layout/TopBar.test.tsx
@@ -104,7 +104,7 @@ describe("TopBar", () => {
   it("displays navigation links", () => {
     renderTopBar();
 
-    expect(screen.getByTestId("nav-link-/")).toBeInTheDocument();
+    expect(screen.getByTestId("nav-link-/feed")).toBeInTheDocument();
     expect(screen.getByTestId("nav-link-/practice")).toBeInTheDocument();
     expect(screen.getByTestId("nav-link-/task-library")).toBeInTheDocument();
     expect(screen.getByTestId("nav-link-/growth")).toBeInTheDocument();

--- a/frontend/src/components/layout/TopBar.tsx
+++ b/frontend/src/components/layout/TopBar.tsx
@@ -46,7 +46,7 @@ export function TopBar() {
           )}
           <nav className="flex flex-col gap-2 mt-4">
             <NavLink
-              to="/"
+              to="/feed"
               className={({ isActive }) =>
                 `px-3 py-2 rounded-md transition-colors text-base font-medium ${
                   isActive

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -124,7 +124,7 @@ ReactDOM.createRoot(root).render(
                 index
                 element={
                   <Suspense fallback={<LoadingScreen />}>
-                    <Feed />
+                    <About />
                   </Suspense>
                 }
               />


### PR DESCRIPTION
I think ideally I'd route users to the feed once they know how to use the app, but when is that point? I think for the time being, I can error on the side of just routing people redundantly to the about page. 
If I get regular users, I can update this to track login state or newness and conditionally render a page