### PR TITLE
PROD - bugfixes: see description for details

### DIFF
--- a/api/src/config/security.config.ts
+++ b/api/src/config/security.config.ts
@@ -58,6 +58,7 @@ export const SecurityConfig = {
       'X-Requested-With',
       'Accept',
       'Origin',
+      'x-csrf-token',
     ],
   },
 

--- a/frontend/src/components/MediaFallback.test.tsx
+++ b/frontend/src/components/MediaFallback.test.tsx
@@ -1,0 +1,214 @@
+import React from "react";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { vi } from "vitest";
+import { MediaFallback } from "./MediaFallback";
+
+describe("MediaFallback", () => {
+  const mockOnError = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("Image Handling", () => {
+    it("renders image when URL is valid", () => {
+      render(
+        <MediaFallback
+          url="https://example.com/image.jpg"
+          type="image"
+          displayName="Test Image"
+          className="test-class"
+        />
+      );
+
+      const img = screen.getByAltText("Test Image");
+      expect(img).toBeInTheDocument();
+      expect(img).toHaveClass("test-class");
+    });
+
+    it("falls back to thumbnail when image fails and thumbnail is available", () => {
+      render(
+        <MediaFallback
+          url="https://invalid-url.com/image.jpg"
+          type="image"
+          thumbnailUrl="https://example.com/thumb.jpg"
+          displayName="Test Image"
+        />
+      );
+
+      const img = screen.getByAltText("Test Image");
+      expect(img).toBeInTheDocument();
+
+      // Simulate image load error to trigger thumbnail fallback
+      fireEvent.error(img);
+
+      // Should now show thumbnail
+      const thumbnailImg = screen.getByAltText("Test Image");
+      expect(thumbnailImg.src).toContain("thumb.jpg");
+    });
+
+    it("shows icon when image fails and no thumbnail available", () => {
+      render(
+        <MediaFallback
+          url="https://invalid-url.com/image.jpg"
+          type="image"
+          displayName="Test Image"
+        />
+      );
+
+      // Simulate image load error
+      const img = screen.getByAltText("Test Image");
+      fireEvent.error(img);
+
+      // Should show fallback icon
+      expect(screen.getByTestId("image-icon")).toBeInTheDocument();
+    });
+  });
+
+  describe("Video Handling", () => {
+    it("renders video when no thumbnail available", () => {
+      render(
+        <MediaFallback
+          url="https://example.com/video.mp4"
+          type="video"
+          displayName="Test Video"
+        />
+      );
+
+      const video = screen.getByTestId("video-element");
+      expect(video).toBeInTheDocument();
+    });
+
+    it("renders thumbnail when available", () => {
+      render(
+        <MediaFallback
+          url="https://example.com/video.mp4"
+          type="video"
+          thumbnailUrl="https://example.com/thumb.jpg"
+          displayName="Test Video"
+        />
+      );
+
+      const img = screen.getByAltText("Test Video");
+      expect(img).toBeInTheDocument();
+      expect(img.src).toContain("thumb.jpg");
+    });
+
+    it("shows icon when video fails", () => {
+      render(
+        <MediaFallback
+          url="https://invalid-url.com/video.mp4"
+          type="video"
+          displayName="Test Video"
+        />
+      );
+
+      // Simulate video load error
+      const video = screen.getByTestId("video-element");
+      fireEvent.error(video);
+
+      // Should show fallback icon
+      expect(screen.getByTestId("video-icon")).toBeInTheDocument();
+    });
+  });
+
+  describe("Audio Handling", () => {
+    it("always shows audio icon", () => {
+      render(
+        <MediaFallback
+          url="https://example.com/audio.mp3"
+          type="audio"
+          displayName="Test Audio"
+        />
+      );
+
+      expect(screen.getByTestId("music-icon")).toBeInTheDocument();
+    });
+  });
+
+  describe("Icon Sizing", () => {
+    it("applies small icon size", () => {
+      render(
+        <MediaFallback
+          url="https://invalid-url.com/image.jpg"
+          type="image"
+          iconSize="sm"
+        />
+      );
+
+      // Simulate error to show fallback
+      const img = screen.getByAltText("Media");
+      fireEvent.error(img);
+
+      const icon = screen.getByTestId("image-icon");
+      expect(icon).toHaveClass("w-4 h-4");
+    });
+
+    it("applies medium icon size", () => {
+      render(
+        <MediaFallback
+          url="https://invalid-url.com/image2.jpg"
+          type="image"
+          iconSize="md"
+        />
+      );
+
+      const img = screen.getByAltText("Media");
+      fireEvent.error(img);
+      expect(screen.getByTestId("image-icon")).toHaveClass("w-6 h-6");
+    });
+
+    it("applies large icon size", () => {
+      render(
+        <MediaFallback
+          url="https://invalid-url.com/image3.jpg"
+          type="image"
+          iconSize="lg"
+        />
+      );
+
+      const img = screen.getByAltText("Media");
+      fireEvent.error(img);
+      expect(screen.getByTestId("image-icon")).toHaveClass("w-8 h-8");
+    });
+  });
+
+  describe("Error Handling", () => {
+    it("calls onError callback when media fails", () => {
+      render(
+        <MediaFallback
+          url="https://invalid-url.com/image.jpg"
+          type="image"
+          onError={mockOnError}
+        />
+      );
+
+      const img = screen.getByAltText("Media");
+      fireEvent.error(img);
+
+      expect(mockOnError).toHaveBeenCalled();
+    });
+
+    it("calls onFallback callback when fallback state changes", () => {
+      const mockOnFallback = vi.fn();
+
+      render(
+        <MediaFallback
+          url="https://invalid-url.com/image.jpg"
+          type="image"
+          onFallback={mockOnFallback}
+        />
+      );
+
+      // Initially should not be in fallback state
+      expect(mockOnFallback).toHaveBeenCalledWith(false);
+
+      // Simulate error to trigger fallback
+      const img = screen.getByAltText("Media");
+      fireEvent.error(img);
+
+      // Should now be in fallback state
+      expect(mockOnFallback).toHaveBeenCalledWith(true);
+    });
+  });
+});

--- a/frontend/src/components/MediaFallback.test.tsx
+++ b/frontend/src/components/MediaFallback.test.tsx
@@ -17,7 +17,7 @@ describe("MediaFallback", () => {
     expect(img).toHaveAttribute("src", "https://example.com/image.jpg");
   });
 
-  it("renders video correctly", () => {
+  it("renders video correctly when no thumbnail", () => {
     render(
       <MediaFallback
         url="https://example.com/video.mp4"
@@ -29,6 +29,21 @@ describe("MediaFallback", () => {
     const video = screen.getByTestId("video-element");
     expect(video).toBeInTheDocument();
     expect(video).toHaveAttribute("src", "https://example.com/video.mp4");
+  });
+
+  it("renders video thumbnail when available", () => {
+    render(
+      <MediaFallback
+        url="https://example.com/video.mp4"
+        type="video"
+        thumbnailUrl="https://example.com/thumb.jpg"
+        className="w-full h-full"
+      />
+    );
+
+    const img = screen.getByAltText("Video thumbnail");
+    expect(img).toBeInTheDocument();
+    expect(img).toHaveAttribute("src", "https://example.com/thumb.jpg");
   });
 
   it("renders audio icon correctly", () => {
@@ -84,8 +99,8 @@ describe("MediaFallback", () => {
     expect(screen.getByTestId("image-icon")).toBeInTheDocument();
   });
 
-  it("shows correct icon for different media types", () => {
-    const { rerender } = render(
+  it("shows image fallback icon when image fails", () => {
+    render(
       <MediaFallback
         url="https://example.com/image.jpg"
         type="image"
@@ -98,9 +113,10 @@ describe("MediaFallback", () => {
     fireEvent.error(img);
 
     expect(screen.getByTestId("image-icon")).toBeInTheDocument();
+  });
 
-    // Test video type
-    rerender(
+  it("shows video fallback icon when video fails", () => {
+    render(
       <MediaFallback
         url="https://example.com/video.mp4"
         type="video"
@@ -112,9 +128,10 @@ describe("MediaFallback", () => {
     fireEvent.error(video);
 
     expect(screen.getByTestId("video-icon")).toBeInTheDocument();
+  });
 
-    // Test audio type
-    rerender(
+  it("shows audio icon for audio type", () => {
+    render(
       <MediaFallback
         url="https://example.com/audio.mp3"
         type="audio"
@@ -150,12 +167,13 @@ describe("MediaFallback", () => {
     const img = screen.getByAltText("Media");
     fireEvent.error(img);
 
-    const fallback = screen.getByTestId("image-icon").closest("div");
+    // fallbackClassName applies to the outer div, not the icon container
+    const fallback = screen.getByLabelText("image media");
     expect(fallback).toHaveClass("fallback-class");
   });
 
-  it("renders with different icon sizes", () => {
-    const { rerender } = render(
+  it("renders with small icon size", () => {
+    render(
       <MediaFallback
         url="https://example.com/image.jpg"
         type="image"
@@ -163,40 +181,42 @@ describe("MediaFallback", () => {
       />
     );
 
-    let img = screen.getByAltText("Media");
+    const img = screen.getByAltText("Media");
     fireEvent.error(img);
 
-    let icon = screen.getByTestId("image-icon");
+    const icon = screen.getByTestId("image-icon");
     expect(icon).toHaveClass("w-4", "h-4");
+  });
 
-    // Test medium size
-    rerender(
+  it("renders with medium icon size", () => {
+    render(
       <MediaFallback
-        url="https://example.com/image.jpg"
+        url="https://example.com/image2.jpg"
         type="image"
         iconSize="md"
       />
     );
 
-    img = screen.getByAltText("Media");
+    const img = screen.getByAltText("Media");
     fireEvent.error(img);
 
-    icon = screen.getByTestId("image-icon");
+    const icon = screen.getByTestId("image-icon");
     expect(icon).toHaveClass("w-6", "h-6");
+  });
 
-    // Test large size
-    rerender(
+  it("renders with large icon size", () => {
+    render(
       <MediaFallback
-        url="https://example.com/image.jpg"
+        url="https://example.com/image3.jpg"
         type="image"
         iconSize="lg"
       />
     );
 
-    img = screen.getByAltText("Media");
+    const img = screen.getByAltText("Media");
     fireEvent.error(img);
 
-    icon = screen.getByTestId("image-icon");
+    const icon = screen.getByTestId("image-icon");
     expect(icon).toHaveClass("w-8", "h-8");
   });
 

--- a/frontend/src/components/MediaFallback.test.tsx
+++ b/frontend/src/components/MediaFallback.test.tsx
@@ -1,214 +1,225 @@
-import React from "react";
 import { render, screen, fireEvent } from "@testing-library/react";
-import { vi } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import { MediaFallback } from "./MediaFallback";
 
 describe("MediaFallback", () => {
-  const mockOnError = vi.fn();
+  it("renders image correctly", () => {
+    render(
+      <MediaFallback
+        url="https://example.com/image.jpg"
+        type="image"
+        className="w-full h-full"
+      />
+    );
 
-  beforeEach(() => {
-    vi.clearAllMocks();
+    const img = screen.getByAltText("Media");
+    expect(img).toBeInTheDocument();
+    expect(img).toHaveAttribute("src", "https://example.com/image.jpg");
   });
 
-  describe("Image Handling", () => {
-    it("renders image when URL is valid", () => {
-      render(
-        <MediaFallback
-          url="https://example.com/image.jpg"
-          type="image"
-          displayName="Test Image"
-          className="test-class"
-        />
-      );
+  it("renders video correctly", () => {
+    render(
+      <MediaFallback
+        url="https://example.com/video.mp4"
+        type="video"
+        className="w-full h-full"
+      />
+    );
 
-      const img = screen.getByAltText("Test Image");
-      expect(img).toBeInTheDocument();
-      expect(img).toHaveClass("test-class");
-    });
-
-    it("falls back to thumbnail when image fails and thumbnail is available", () => {
-      render(
-        <MediaFallback
-          url="https://invalid-url.com/image.jpg"
-          type="image"
-          thumbnailUrl="https://example.com/thumb.jpg"
-          displayName="Test Image"
-        />
-      );
-
-      const img = screen.getByAltText("Test Image");
-      expect(img).toBeInTheDocument();
-
-      // Simulate image load error to trigger thumbnail fallback
-      fireEvent.error(img);
-
-      // Should now show thumbnail
-      const thumbnailImg = screen.getByAltText("Test Image");
-      expect(thumbnailImg.src).toContain("thumb.jpg");
-    });
-
-    it("shows icon when image fails and no thumbnail available", () => {
-      render(
-        <MediaFallback
-          url="https://invalid-url.com/image.jpg"
-          type="image"
-          displayName="Test Image"
-        />
-      );
-
-      // Simulate image load error
-      const img = screen.getByAltText("Test Image");
-      fireEvent.error(img);
-
-      // Should show fallback icon
-      expect(screen.getByTestId("image-icon")).toBeInTheDocument();
-    });
+    const video = screen.getByTestId("video-element");
+    expect(video).toBeInTheDocument();
+    expect(video).toHaveAttribute("src", "https://example.com/video.mp4");
   });
 
-  describe("Video Handling", () => {
-    it("renders video when no thumbnail available", () => {
-      render(
-        <MediaFallback
-          url="https://example.com/video.mp4"
-          type="video"
-          displayName="Test Video"
-        />
-      );
+  it("renders audio icon correctly", () => {
+    render(
+      <MediaFallback
+        url="https://example.com/audio.mp3"
+        type="audio"
+        className="w-full h-full"
+      />
+    );
 
-      const video = screen.getByTestId("video-element");
-      expect(video).toBeInTheDocument();
-    });
-
-    it("renders thumbnail when available", () => {
-      render(
-        <MediaFallback
-          url="https://example.com/video.mp4"
-          type="video"
-          thumbnailUrl="https://example.com/thumb.jpg"
-          displayName="Test Video"
-        />
-      );
-
-      const img = screen.getByAltText("Test Video");
-      expect(img).toBeInTheDocument();
-      expect(img.src).toContain("thumb.jpg");
-    });
-
-    it("shows icon when video fails", () => {
-      render(
-        <MediaFallback
-          url="https://invalid-url.com/video.mp4"
-          type="video"
-          displayName="Test Video"
-        />
-      );
-
-      // Simulate video load error
-      const video = screen.getByTestId("video-element");
-      fireEvent.error(video);
-
-      // Should show fallback icon
-      expect(screen.getByTestId("video-icon")).toBeInTheDocument();
-    });
+    expect(screen.getByTestId("music-icon")).toBeInTheDocument();
   });
 
-  describe("Audio Handling", () => {
-    it("always shows audio icon", () => {
-      render(
-        <MediaFallback
-          url="https://example.com/audio.mp3"
-          type="audio"
-          displayName="Test Audio"
-        />
-      );
+  it("falls back to thumbnail for images", () => {
+    render(
+      <MediaFallback
+        url="https://example.com/image.jpg"
+        type="image"
+        thumbnailUrl="https://example.com/thumb.jpg"
+        className="w-full h-full"
+      />
+    );
 
-      expect(screen.getByTestId("music-icon")).toBeInTheDocument();
-    });
+    const img = screen.getByAltText("Media");
+    expect(img).toBeInTheDocument();
+    expect(img).toHaveAttribute("src", "https://example.com/image.jpg");
+
+    // Simulate image load error
+    fireEvent.error(img);
+
+    // Should now show thumbnail
+    const thumbnailImg = screen.getByAltText("Media") as HTMLImageElement;
+    expect(thumbnailImg.src).toContain("thumb.jpg");
   });
 
-  describe("Icon Sizing", () => {
-    it("applies small icon size", () => {
-      render(
-        <MediaFallback
-          url="https://invalid-url.com/image.jpg"
-          type="image"
-          iconSize="sm"
-        />
-      );
+  it("falls back to icon when no thumbnail available", () => {
+    render(
+      <MediaFallback
+        url="https://example.com/image.jpg"
+        type="image"
+        className="w-full h-full"
+      />
+    );
 
-      // Simulate error to show fallback
-      const img = screen.getByAltText("Media");
-      fireEvent.error(img);
+    const img = screen.getByAltText("Media");
+    expect(img).toBeInTheDocument();
 
-      const icon = screen.getByTestId("image-icon");
-      expect(icon).toHaveClass("w-4 h-4");
-    });
+    // Simulate image load error
+    fireEvent.error(img);
 
-    it("applies medium icon size", () => {
-      render(
-        <MediaFallback
-          url="https://invalid-url.com/image2.jpg"
-          type="image"
-          iconSize="md"
-        />
-      );
-
-      const img = screen.getByAltText("Media");
-      fireEvent.error(img);
-      expect(screen.getByTestId("image-icon")).toHaveClass("w-6 h-6");
-    });
-
-    it("applies large icon size", () => {
-      render(
-        <MediaFallback
-          url="https://invalid-url.com/image3.jpg"
-          type="image"
-          iconSize="lg"
-        />
-      );
-
-      const img = screen.getByAltText("Media");
-      fireEvent.error(img);
-      expect(screen.getByTestId("image-icon")).toHaveClass("w-8 h-8");
-    });
+    // Should show fallback icon
+    expect(screen.getByTestId("image-icon")).toBeInTheDocument();
   });
 
-  describe("Error Handling", () => {
-    it("calls onError callback when media fails", () => {
-      render(
-        <MediaFallback
-          url="https://invalid-url.com/image.jpg"
-          type="image"
-          onError={mockOnError}
-        />
-      );
+  it("shows correct icon for different media types", () => {
+    const { rerender } = render(
+      <MediaFallback
+        url="https://example.com/image.jpg"
+        type="image"
+        className="w-full h-full"
+      />
+    );
 
-      const img = screen.getByAltText("Media");
-      fireEvent.error(img);
+    // Simulate error to show fallback
+    const img = screen.getByAltText("Media");
+    fireEvent.error(img);
 
-      expect(mockOnError).toHaveBeenCalled();
-    });
+    expect(screen.getByTestId("image-icon")).toBeInTheDocument();
 
-    it("calls onFallback callback when fallback state changes", () => {
-      const mockOnFallback = vi.fn();
+    // Test video type
+    rerender(
+      <MediaFallback
+        url="https://example.com/video.mp4"
+        type="video"
+        className="w-full h-full"
+      />
+    );
 
-      render(
-        <MediaFallback
-          url="https://invalid-url.com/image.jpg"
-          type="image"
-          onFallback={mockOnFallback}
-        />
-      );
+    const video = screen.getByTestId("video-element");
+    fireEvent.error(video);
 
-      // Initially should not be in fallback state
-      expect(mockOnFallback).toHaveBeenCalledWith(false);
+    expect(screen.getByTestId("video-icon")).toBeInTheDocument();
 
-      // Simulate error to trigger fallback
-      const img = screen.getByAltText("Media");
-      fireEvent.error(img);
+    // Test audio type
+    rerender(
+      <MediaFallback
+        url="https://example.com/audio.mp3"
+        type="audio"
+        className="w-full h-full"
+      />
+    );
 
-      // Should now be in fallback state
-      expect(mockOnFallback).toHaveBeenCalledWith(true);
-    });
+    expect(screen.getByTestId("music-icon")).toBeInTheDocument();
+  });
+
+  it("applies custom className", () => {
+    render(
+      <MediaFallback
+        url="https://example.com/image.jpg"
+        type="image"
+        className="custom-class"
+      />
+    );
+
+    const img = screen.getByAltText("Media");
+    expect(img).toHaveClass("custom-class");
+  });
+
+  it("applies fallback className", () => {
+    render(
+      <MediaFallback
+        url="https://example.com/image.jpg"
+        type="image"
+        fallbackClassName="fallback-class"
+      />
+    );
+
+    const img = screen.getByAltText("Media");
+    fireEvent.error(img);
+
+    const fallback = screen.getByTestId("image-icon").closest("div");
+    expect(fallback).toHaveClass("fallback-class");
+  });
+
+  it("renders with different icon sizes", () => {
+    const { rerender } = render(
+      <MediaFallback
+        url="https://example.com/image.jpg"
+        type="image"
+        iconSize="sm"
+      />
+    );
+
+    let img = screen.getByAltText("Media");
+    fireEvent.error(img);
+
+    let icon = screen.getByTestId("image-icon");
+    expect(icon).toHaveClass("w-4", "h-4");
+
+    // Test medium size
+    rerender(
+      <MediaFallback
+        url="https://example.com/image.jpg"
+        type="image"
+        iconSize="md"
+      />
+    );
+
+    img = screen.getByAltText("Media");
+    fireEvent.error(img);
+
+    icon = screen.getByTestId("image-icon");
+    expect(icon).toHaveClass("w-6", "h-6");
+
+    // Test large size
+    rerender(
+      <MediaFallback
+        url="https://example.com/image.jpg"
+        type="image"
+        iconSize="lg"
+      />
+    );
+
+    img = screen.getByAltText("Media");
+    fireEvent.error(img);
+
+    icon = screen.getByTestId("image-icon");
+    expect(icon).toHaveClass("w-8", "h-8");
+  });
+
+  it("calls onFallback callback when fallback state changes", () => {
+    const mockOnFallback = vi.fn();
+
+    render(
+      <MediaFallback
+        url="https://example.com/image.jpg"
+        type="image"
+        onFallback={mockOnFallback}
+      />
+    );
+
+    const img = screen.getByAltText("Media");
+
+    // Initially should not be in fallback state
+    expect(mockOnFallback).toHaveBeenCalledWith(false);
+
+    // Simulate error to trigger fallback
+    fireEvent.error(img);
+
+    // Should now be in fallback state
+    expect(mockOnFallback).toHaveBeenCalledWith(true);
   });
 });

--- a/frontend/src/components/MediaFallback.tsx
+++ b/frontend/src/components/MediaFallback.tsx
@@ -1,0 +1,150 @@
+import React, { useState, useEffect } from "react";
+import { Music, Video, Image, File } from "lucide-react";
+
+interface MediaFallbackProps {
+  url: string;
+  type: string;
+  displayName?: string;
+  thumbnailUrl?: string;
+  className?: string;
+  alt?: string;
+  fallbackClassName?: string;
+  iconSize?: "sm" | "md" | "lg";
+  onError?: (error: Event) => void;
+  onFallback?: (isFallback: boolean) => void;
+}
+
+export const MediaFallback: React.FC<MediaFallbackProps> = ({
+  url,
+  type,
+  displayName,
+  thumbnailUrl,
+  className = "",
+  alt,
+  fallbackClassName = "",
+  iconSize = "md",
+  onError,
+  onFallback,
+}) => {
+  const [hasError, setHasError] = useState(false);
+  const [useThumbnail, setUseThumbnail] = useState(false);
+
+  // Notify parent component when fallback state changes
+  useEffect(() => {
+    const isInFallback = hasError && !useThumbnail;
+    onFallback?.(isInFallback);
+  }, [hasError, useThumbnail, onFallback]);
+
+  const getIconSize = () => {
+    switch (iconSize) {
+      case "sm":
+        return "w-4 h-4";
+      case "lg":
+        return "w-8 h-8";
+      default:
+        return "w-6 h-6";
+    }
+  };
+
+  const getMediaTypeIcon = (mediaType: string) => {
+    switch (mediaType) {
+      case "image":
+        return <Image className={getIconSize()} data-testid="image-icon" />;
+      case "audio":
+        return <Music className={getIconSize()} data-testid="music-icon" />;
+      case "video":
+        return <Video className={getIconSize()} data-testid="video-icon" />;
+      default:
+        return <File className={getIconSize()} data-testid="file-icon" />;
+    }
+  };
+
+  const handleImageError = (
+    e: React.SyntheticEvent<HTMLImageElement, Event>
+  ) => {
+    if (thumbnailUrl && !useThumbnail) {
+      // Try thumbnail first
+      setUseThumbnail(true);
+      setHasError(false);
+    } else {
+      // Fallback to icon
+      setHasError(true);
+      onError?.(e.nativeEvent);
+    }
+  };
+
+  const handleVideoError = (
+    e: React.SyntheticEvent<HTMLVideoElement, Event>
+  ) => {
+    setHasError(true);
+    onError?.(e.nativeEvent);
+  };
+
+  // If we have an error and no thumbnail to try, show icon
+  if (hasError && !useThumbnail) {
+    return (
+      <div
+        className={`flex items-center justify-center bg-muted/50 ${fallbackClassName}`}
+        aria-label={`${type} media`}
+      >
+        <div className="text-muted-foreground">{getMediaTypeIcon(type)}</div>
+      </div>
+    );
+  }
+
+  // Render based on media type
+  switch (type) {
+    case "image":
+      return (
+        <img
+          src={useThumbnail ? thumbnailUrl! : url}
+          alt={alt || displayName || "Media"}
+          className={className}
+          onError={handleImageError}
+        />
+      );
+
+    case "video":
+      if (thumbnailUrl) {
+        return (
+          <img
+            src={thumbnailUrl}
+            alt={alt || displayName || "Video thumbnail"}
+            className={className}
+            onError={handleImageError}
+          />
+        );
+      }
+      return (
+        <video
+          src={url}
+          className={className}
+          muted
+          preload="metadata"
+          onError={handleVideoError}
+          data-testid="video-element"
+        />
+      );
+
+    case "audio":
+      // Audio always shows icon - no URL dependency
+      return (
+        <div
+          className={`flex items-center justify-center bg-muted/50 ${fallbackClassName}`}
+          aria-label="Audio media"
+        >
+          <div className="text-muted-foreground">{getMediaTypeIcon(type)}</div>
+        </div>
+      );
+
+    default:
+      return (
+        <div
+          className={`flex items-center justify-center bg-muted/50 ${fallbackClassName}`}
+          aria-label={`${type} media`}
+        >
+          <div className="text-muted-foreground">{getMediaTypeIcon(type)}</div>
+        </div>
+      );
+  }
+};

--- a/frontend/src/components/MediaGallery.test.tsx
+++ b/frontend/src/components/MediaGallery.test.tsx
@@ -104,7 +104,7 @@ describe("MediaGallery", () => {
       render(<MediaGallery media={media} />);
 
       expect(screen.getByAltText("video1.mp4")).toBeInTheDocument();
-      expect(screen.getAllByTestId("video-icon")).toHaveLength(2); // fallback + file type icon
+      expect(screen.getAllByTestId("video-icon")).toHaveLength(1); // Only file type icon
     });
 
     it("renders videos without thumbnails correctly", () => {
@@ -119,10 +119,9 @@ describe("MediaGallery", () => {
 
       render(<MediaGallery media={media} />);
 
-      const video = document.querySelector("video") as HTMLVideoElement;
+      const video = screen.getByTestId("video-element");
       expect(video).toBeInTheDocument();
       expect(video).toHaveAttribute("src", "https://example.com/video1.mp4");
-      expect(video).toHaveAttribute("poster", "https://example.com/video1.mp4");
     });
 
     it("renders mixed media types correctly", () => {
@@ -154,7 +153,7 @@ describe("MediaGallery", () => {
       expect(screen.getByTestId("audio-player-2")).toBeInTheDocument();
       expect(screen.getByAltText("video.mp4")).toBeInTheDocument();
       expect(screen.getAllByTestId("image-icon")).toHaveLength(1);
-      expect(screen.getAllByTestId("video-icon")).toHaveLength(2); // fallback + file type icon
+      expect(screen.getAllByTestId("video-icon")).toHaveLength(1); // Only file type icon
     });
   });
 
@@ -354,17 +353,13 @@ describe("MediaGallery", () => {
 
       render(<MediaGallery media={media} />);
 
-      const video = document.querySelector("video") as HTMLVideoElement;
+      const video = screen.getByTestId("video-element");
 
       // Simulate video load error
       fireEvent.error(video);
 
       // The fallback should be visible
-      const fallback = video.parentElement?.querySelector(".video-fallback");
-      expect(fallback).toHaveClass("hidden");
-      // Note: The actual display change happens via CSS, which is hard to test
-      // We can at least verify the fallback element exists
-      expect(fallback).toBeInTheDocument();
+      expect(screen.getByTestId("video-icon")).toBeInTheDocument();
     });
   });
 
@@ -412,7 +407,7 @@ describe("MediaGallery", () => {
 
       render(<MediaGallery media={media} />);
 
-      expect(screen.getAllByTestId("video-icon")).toHaveLength(2); // fallback + file type icon
+      expect(screen.getAllByTestId("video-icon")).toHaveLength(1); // Only file type icon
     });
 
     it("filters out unknown types", () => {
@@ -479,7 +474,7 @@ describe("MediaGallery", () => {
 
       render(<MediaGallery media={media} />);
 
-      const image = screen.getByAltText("Uploaded image");
+      const image = screen.getByAltText("Media");
       expect(image).toBeInTheDocument();
     });
   });

--- a/frontend/src/components/MediaGallery.tsx
+++ b/frontend/src/components/MediaGallery.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { X, Image, Music, Video, File } from "lucide-react";
 import { Button } from "./ui/button";
 import { AudioPlayer } from "./AudioPlayer";
+import { MediaFallback } from "./MediaFallback";
 
 interface MediaItem {
   id?: string;
@@ -95,10 +96,13 @@ export const MediaGallery: React.FC<MediaGalleryProps> = ({
                 key={item.id || index}
                 className="relative rounded-lg overflow-hidden bg-muted border"
               >
-                <img
-                  src={item.url}
-                  alt={item.fileName || "Uploaded image"}
+                <MediaFallback
+                  url={item.url}
+                  type={item.type}
+                  displayName={item.fileName}
                   className="w-full h-32 md:h-40 object-cover"
+                  fallbackClassName="w-full h-32 md:h-40"
+                  iconSize="lg"
                 />
                 {/* File type icon */}
                 <div className="absolute top-2 left-2 bg-black/50 text-white p-1 rounded">
@@ -127,34 +131,15 @@ export const MediaGallery: React.FC<MediaGalleryProps> = ({
                 key={item.id || index}
                 className="relative rounded-lg overflow-hidden bg-muted border"
               >
-                {item.thumbnailUrl ? (
-                  <img
-                    src={item.thumbnailUrl}
-                    alt={item.fileName || "Video thumbnail"}
-                    className="w-full h-32 md:h-40 object-cover"
-                  />
-                ) : (
-                  <video
-                    src={item.url}
-                    className="w-full h-32 md:h-40 object-cover"
-                    muted
-                    preload="metadata"
-                    poster={item.url}
-                    onError={(e) => {
-                      // Fallback to video icon if video fails to load
-                      const target = e.target as HTMLVideoElement;
-                      target.style.display = "none";
-                      const fallback = target.parentElement?.querySelector(
-                        ".video-fallback"
-                      ) as HTMLElement;
-                      if (fallback) fallback.style.display = "flex";
-                    }}
-                  />
-                )}
-                {/* Fallback video icon */}
-                <div className="video-fallback hidden absolute inset-0 bg-muted flex items-center justify-center">
-                  <Video className="w-8 h-8 text-muted-foreground" />
-                </div>
+                <MediaFallback
+                  url={item.url}
+                  type={item.type}
+                  displayName={item.fileName}
+                  thumbnailUrl={item.thumbnailUrl}
+                  className="w-full h-32 md:h-40 object-cover"
+                  fallbackClassName="w-full h-32 md:h-40"
+                  iconSize="lg"
+                />
                 {/* File type icon */}
                 <div className="absolute top-2 left-2 bg-black/50 text-white p-1 rounded">
                   {getFileTypeIcon(item.type)}

--- a/frontend/src/components/MediaGallery.tsx
+++ b/frontend/src/components/MediaGallery.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useState } from "react";
 import { X, Image, Music, Video, File } from "lucide-react";
 import { Button } from "./ui/button";
 import { AudioPlayer } from "./AudioPlayer";
@@ -19,15 +19,13 @@ interface MediaGalleryProps {
   className?: string;
 }
 
-export const MediaGallery: React.FC<MediaGalleryProps> = ({
-  media,
-  onRemove,
-  className = "",
-}) => {
-  // Separate media types
-  const photos = media.filter((item) => item.type === "image");
-  const audioFiles = media.filter((item) => item.type === "audio");
-  const videos = media.filter((item) => item.type === "video");
+// Separate component to handle individual media items with fallback state
+const MediaGalleryItem: React.FC<{
+  item: MediaItem;
+  originalIndex: number;
+  onRemove?: (index: number) => void;
+}> = ({ item, originalIndex, onRemove }) => {
+  const [isFallback, setIsFallback] = useState(false);
 
   const getFileTypeIcon = (type: string) => {
     switch (type) {
@@ -41,6 +39,49 @@ export const MediaGallery: React.FC<MediaGalleryProps> = ({
         return <File className="w-4 h-4" />;
     }
   };
+
+  return (
+    <div className="relative rounded-lg overflow-hidden bg-muted border">
+      <MediaFallback
+        url={item.url}
+        type={item.type}
+        displayName={item.fileName}
+        thumbnailUrl={item.thumbnailUrl}
+        className="w-full h-32 md:h-40 object-cover"
+        fallbackClassName="w-full h-32 md:h-40"
+        iconSize="lg"
+        onFallback={setIsFallback}
+      />
+      {/* File type icon - hidden for fallback states */}
+      {!isFallback && (
+        <div className="absolute top-2 left-2 bg-black/50 text-white p-1 rounded">
+          {getFileTypeIcon(item.type)}
+        </div>
+      )}
+      {onRemove && (
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          onClick={() => onRemove(originalIndex)}
+          className="absolute top-2 right-2 h-6 w-6 p-0 bg-black/50 text-white hover:bg-black/70"
+        >
+          <X className="h-3 w-3" />
+        </Button>
+      )}
+    </div>
+  );
+};
+
+export const MediaGallery: React.FC<MediaGalleryProps> = ({
+  media,
+  onRemove,
+  className = "",
+}) => {
+  // Separate media types
+  const photos = media.filter((item) => item.type === "image");
+  const audioFiles = media.filter((item) => item.type === "audio");
+  const videos = media.filter((item) => item.type === "video");
 
   if (media.length === 0) {
     return (
@@ -92,34 +133,12 @@ export const MediaGallery: React.FC<MediaGalleryProps> = ({
           {photos.map((item, index) => {
             const originalIndex = media.findIndex((m) => m === item);
             return (
-              <div
+              <MediaGalleryItem
                 key={item.id || index}
-                className="relative rounded-lg overflow-hidden bg-muted border"
-              >
-                <MediaFallback
-                  url={item.url}
-                  type={item.type}
-                  displayName={item.fileName}
-                  className="w-full h-32 md:h-40 object-cover"
-                  fallbackClassName="w-full h-32 md:h-40"
-                  iconSize="lg"
-                />
-                {/* File type icon */}
-                <div className="absolute top-2 left-2 bg-black/50 text-white p-1 rounded">
-                  {getFileTypeIcon(item.type)}
-                </div>
-                {onRemove && (
-                  <Button
-                    type="button"
-                    variant="ghost"
-                    size="sm"
-                    onClick={() => onRemove(originalIndex)}
-                    className="absolute top-2 right-2 h-6 w-6 p-0 bg-black/50 text-white hover:bg-black/70"
-                  >
-                    <X className="h-3 w-3" />
-                  </Button>
-                )}
-              </div>
+                item={item}
+                originalIndex={originalIndex}
+                onRemove={onRemove}
+              />
             );
           })}
 
@@ -127,35 +146,12 @@ export const MediaGallery: React.FC<MediaGalleryProps> = ({
           {videos.map((item, index) => {
             const originalIndex = media.findIndex((m) => m === item);
             return (
-              <div
+              <MediaGalleryItem
                 key={item.id || index}
-                className="relative rounded-lg overflow-hidden bg-muted border"
-              >
-                <MediaFallback
-                  url={item.url}
-                  type={item.type}
-                  displayName={item.fileName}
-                  thumbnailUrl={item.thumbnailUrl}
-                  className="w-full h-32 md:h-40 object-cover"
-                  fallbackClassName="w-full h-32 md:h-40"
-                  iconSize="lg"
-                />
-                {/* File type icon */}
-                <div className="absolute top-2 left-2 bg-black/50 text-white p-1 rounded">
-                  {getFileTypeIcon(item.type)}
-                </div>
-                {onRemove && (
-                  <Button
-                    type="button"
-                    variant="ghost"
-                    size="sm"
-                    onClick={() => onRemove(originalIndex)}
-                    className="absolute top-2 right-2 h-6 w-6 p-0 bg-black/50 text-white hover:bg-black/70"
-                  >
-                    <X className="h-3 w-3" />
-                  </Button>
-                )}
-              </div>
+                item={item}
+                originalIndex={originalIndex}
+                onRemove={onRemove}
+              />
             );
           })}
         </div>

--- a/frontend/src/components/MediaGalleryModal.test.tsx
+++ b/frontend/src/components/MediaGalleryModal.test.tsx
@@ -96,10 +96,9 @@ describe("MediaGalleryModal", () => {
 
       render(<MediaGalleryModal media={media} />);
 
-      const video = document.querySelector("video");
+      const video = screen.getByTestId("video-element");
       expect(video).toBeInTheDocument();
       expect(video).toHaveAttribute("src", "https://example.com/video1.mp4");
-      expect(video).toHaveAttribute("poster", "https://example.com/video1.mp4");
     });
 
     it("renders audio files correctly", () => {
@@ -615,14 +614,13 @@ describe("MediaGalleryModal", () => {
 
       render(<MediaGalleryModal media={media} />);
 
-      const video = document.querySelector("video");
+      const video = screen.getByTestId("video-element");
 
       // Simulate video load error
-      fireEvent.error(video!);
+      fireEvent.error(video);
 
       // The fallback should be visible
-      const fallback = video?.parentElement?.querySelector(".video-fallback");
-      expect(fallback).toBeInTheDocument();
+      expect(screen.getAllByTestId("video-icon")).toHaveLength(2);
     });
 
     it("handles video playback errors gracefully", () => {
@@ -685,7 +683,7 @@ describe("MediaGalleryModal", () => {
 
       render(<MediaGalleryModal media={media} />);
 
-      expect(screen.getAllByTestId("video-icon")).toHaveLength(2); // fallback + file type icon
+      expect(screen.getAllByTestId("video-icon")).toHaveLength(1); // Only file type icon
     });
 
     it("does not render unknown media types", () => {

--- a/frontend/src/components/MediaGalleryModal.tsx
+++ b/frontend/src/components/MediaGalleryModal.tsx
@@ -31,30 +31,71 @@ export const MediaGalleryModal: React.FC<MediaGalleryModalProps> = ({
     null
   );
 
+  // Define functions that will be used in useEffect
+  const closeModal = () => {
+    setSelectedImageIndex(null);
+  };
+
+  const nextImage = () => {
+    if (selectedImageIndex !== null && media) {
+      const photos = media.filter((item) => item.type === "image");
+      const videos = media.filter((item) => item.type === "video");
+      const imageAndVideoMedia = [...photos, ...videos];
+      setSelectedImageIndex(
+        (selectedImageIndex + 1) % imageAndVideoMedia.length
+      );
+    }
+  };
+
+  const prevImage = () => {
+    if (selectedImageIndex !== null && media) {
+      const photos = media.filter((item) => item.type === "image");
+      const videos = media.filter((item) => item.type === "video");
+      const imageAndVideoMedia = [...photos, ...videos];
+      setSelectedImageIndex(
+        selectedImageIndex === 0
+          ? imageAndVideoMedia.length - 1
+          : selectedImageIndex - 1
+      );
+    }
+  };
+
   // Keyboard navigation
   useEffect(() => {
-    const handleKeyDown = (event: KeyboardEvent) => {
-      if (selectedImageIndex === null) return;
-
-      switch (event.key) {
-        case "Escape":
-          event.preventDefault();
-          closeModal();
-          break;
-        case "ArrowLeft":
-          event.preventDefault();
-          prevImage();
-          break;
-        case "ArrowRight":
-          event.preventDefault();
-          nextImage();
-          break;
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (selectedImageIndex !== null) {
+        switch (e.key) {
+          case "Escape":
+            closeModal();
+            break;
+          case "ArrowRight":
+            nextImage();
+            break;
+          case "ArrowLeft":
+            prevImage();
+            break;
+        }
       }
     };
 
     document.addEventListener("keydown", handleKeyDown);
     return () => document.removeEventListener("keydown", handleKeyDown);
   }, [selectedImageIndex]);
+
+  if (!media || media.length === 0) {
+    return null;
+  }
+
+  // Separate media types
+  const photos = media.filter((item) => item.type === "image");
+  const audioFiles = media.filter((item) => item.type === "audio");
+  const videos = media.filter((item) => item.type === "video");
+
+  // Combine photos and videos for modal navigation
+  const imageAndVideoMedia = [...photos, ...videos];
+
+  const selectedMedia =
+    selectedImageIndex !== null ? imageAndVideoMedia[selectedImageIndex] : null;
 
   const handleImageClick = (index: number) => {
     setSelectedImageIndex(index);
@@ -72,47 +113,6 @@ export const MediaGalleryModal: React.FC<MediaGalleryModalProps> = ({
         return <Image className="w-4 h-4" />;
     }
   };
-
-  const closeModal = () => {
-    setSelectedImageIndex(null);
-  };
-
-  const nextImage = () => {
-    if (selectedImageIndex !== null) {
-      setSelectedImageIndex(
-        (selectedImageIndex + 1) %
-          media.filter((m) => m.type === "image" || m.type === "video").length
-      );
-    }
-  };
-
-  const prevImage = () => {
-    if (selectedImageIndex !== null) {
-      const imageAndVideoMedia = media.filter(
-        (m) => m.type === "image" || m.type === "video"
-      );
-      setSelectedImageIndex(
-        selectedImageIndex === 0
-          ? imageAndVideoMedia.length - 1
-          : selectedImageIndex - 1
-      );
-    }
-  };
-
-  if (!media || media.length === 0) {
-    return null;
-  }
-
-  const imageAndVideoMedia = media.filter(
-    (m) => m.type === "image" || m.type === "video"
-  );
-  const selectedMedia =
-    selectedImageIndex !== null ? imageAndVideoMedia[selectedImageIndex] : null;
-
-  // Separate media types for display
-  const photos = media.filter((item) => item.type === "image");
-  const audioFiles = media.filter((item) => item.type === "audio");
-  const videos = media.filter((item) => item.type === "video");
 
   return (
     <>

--- a/frontend/src/components/MediaGalleryModal.tsx
+++ b/frontend/src/components/MediaGalleryModal.tsx
@@ -8,8 +8,8 @@ import {
   Video,
 } from "lucide-react";
 import { Button } from "./ui/button";
-
 import { AudioPlayer } from "./AudioPlayer";
+import { MediaFallback } from "./MediaFallback";
 
 interface MediaItem {
   url: string;
@@ -143,10 +143,13 @@ export const MediaGalleryModal: React.FC<MediaGalleryModalProps> = ({
               className="relative rounded-lg overflow-hidden bg-muted cursor-pointer hover:opacity-90 transition-opacity"
               onClick={() => handleImageClick(index)}
             >
-              <img
-                src={item.url}
-                alt="Media"
+              <MediaFallback
+                url={item.url}
+                type={item.type}
+                displayName={item.displayName}
                 className="w-full h-32 md:h-40 object-cover"
+                fallbackClassName="w-full h-32 md:h-40"
+                iconSize="lg"
               />
               <div className="absolute top-2 left-2">
                 <div className="bg-black/50 text-white p-1 rounded">
@@ -165,34 +168,15 @@ export const MediaGalleryModal: React.FC<MediaGalleryModalProps> = ({
                 className="relative rounded-lg overflow-hidden bg-muted cursor-pointer hover:opacity-90 transition-opacity"
                 onClick={() => handleImageClick(videoIndex)}
               >
-                {item.thumbnailUrl ? (
-                  <img
-                    src={item.thumbnailUrl}
-                    alt={item.displayName || "Video thumbnail"}
-                    className="w-full h-32 md:h-40 object-cover"
-                  />
-                ) : (
-                  <video
-                    src={item.url}
-                    className="w-full h-32 md:h-40 object-cover"
-                    muted
-                    preload="metadata"
-                    poster={item.url}
-                    onError={(e) => {
-                      // Fallback to video icon if video fails to load
-                      const target = e.target as HTMLVideoElement;
-                      target.style.display = "none";
-                      const fallback = target.parentElement?.querySelector(
-                        ".video-fallback"
-                      ) as HTMLElement;
-                      if (fallback) fallback.style.display = "flex";
-                    }}
-                  />
-                )}
-                {/* Fallback video icon */}
-                <div className="video-fallback hidden absolute inset-0 bg-muted flex items-center justify-center">
-                  <Video className="w-8 h-8 text-muted-foreground" />
-                </div>
+                <MediaFallback
+                  url={item.url}
+                  type={item.type}
+                  displayName={item.displayName}
+                  thumbnailUrl={item.thumbnailUrl}
+                  className="w-full h-32 md:h-40 object-cover"
+                  fallbackClassName="w-full h-32 md:h-40"
+                  iconSize="lg"
+                />
                 <div className="absolute top-2 left-2">
                   <div className="bg-black/50 text-white p-1 rounded">
                     {getFileTypeIcon(item.type)}

--- a/frontend/src/components/MediaThumbnail.test.tsx
+++ b/frontend/src/components/MediaThumbnail.test.tsx
@@ -74,9 +74,9 @@ describe("MediaThumbnail", () => {
 
       render(<MediaThumbnail media={media} />);
 
-      const audioIcon = document.querySelector(".lucide-music");
+      const audioIcon = screen.getByTestId("music-icon");
       expect(audioIcon).toBeInTheDocument();
-      expect(audioIcon).toHaveClass("w-6", "h-6", "text-muted-foreground");
+      expect(audioIcon).toHaveClass("w-6", "h-6");
     });
 
     it("shows audio icon overlay", () => {
@@ -114,7 +114,7 @@ describe("MediaThumbnail", () => {
       expect(thumbnail).toHaveClass("w-full", "h-full", "object-cover");
     });
 
-    it("renders video icon when no thumbnail", () => {
+    it("renders video element when no thumbnail", () => {
       const media = [
         {
           url: "https://example.com/video.mp4",
@@ -124,9 +124,9 @@ describe("MediaThumbnail", () => {
 
       render(<MediaThumbnail media={media} />);
 
-      const videoIcon = document.querySelector(".lucide-video");
-      expect(videoIcon).toBeInTheDocument();
-      expect(videoIcon).toHaveClass("w-6", "h-6", "text-muted-foreground");
+      const videoElement = screen.getByTestId("video-element");
+      expect(videoElement).toBeInTheDocument();
+      expect(videoElement).toHaveClass("w-full", "h-full", "object-cover");
     });
 
     it("uses default alt text when no displayName", () => {

--- a/frontend/src/components/MediaThumbnail.tsx
+++ b/frontend/src/components/MediaThumbnail.tsx
@@ -1,5 +1,6 @@
-import React from "react";
+import React, { useState } from "react";
 import { Music, Video, Image } from "lucide-react";
+import { MediaFallback } from "./MediaFallback";
 
 interface MediaThumbnailProps {
   media: Array<{
@@ -39,42 +40,32 @@ export const MediaThumbnail: React.FC<MediaThumbnailProps> = ({
   return (
     <div className={`flex gap-2 ${className}`}>
       {displayMedia.map((item, index) => {
+        const [isFallback, setIsFallback] = useState(false);
+
         return (
           <div
             key={index}
             className="relative w-16 h-16 rounded-md overflow-hidden bg-muted flex-shrink-0"
           >
-            {item.type === "image" && (
-              <img
-                src={item.url}
-                alt="Media"
-                className="w-full h-full object-cover"
-              />
-            )}
-            {item.type === "audio" && (
-              <div className="w-full h-full flex items-center justify-center">
-                <Music className="w-6 h-6 text-muted-foreground" />
-              </div>
-            )}
-            {item.type === "video" &&
-              (item.thumbnailUrl ? (
-                <img
-                  src={item.thumbnailUrl}
-                  alt={item.displayName || "Video thumbnail"}
-                  className="w-full h-full object-cover"
-                />
-              ) : (
-                <div className="w-full h-full flex items-center justify-center">
-                  <Video className="w-6 h-6 text-muted-foreground" />
-                </div>
-              ))}
+            <MediaFallback
+              url={item.url}
+              type={item.type}
+              displayName={item.displayName}
+              thumbnailUrl={item.thumbnailUrl}
+              className="w-full h-full object-cover"
+              fallbackClassName="w-full h-full"
+              iconSize="md"
+              onFallback={setIsFallback}
+            />
 
-            {/* File type icon overlay */}
-            <div className="absolute top-1 left-1">
-              <div className="bg-black/50 text-white p-0.5 rounded">
-                {getFileTypeIcon(item.type)}
+            {/* File type icon overlay - hidden for fallback states */}
+            {!isFallback && (
+              <div className="absolute top-1 left-1 pointer-events-none">
+                <div className="bg-black/50 text-white p-0.5 rounded">
+                  {getFileTypeIcon(item.type)}
+                </div>
               </div>
-            </div>
+            )}
           </div>
         );
       })}

--- a/frontend/src/components/MediaThumbnail.tsx
+++ b/frontend/src/components/MediaThumbnail.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React from "react";
 import { Music, Video, Image } from "lucide-react";
 import { MediaFallback } from "./MediaFallback";
 
@@ -12,17 +12,16 @@ interface MediaThumbnailProps {
   className?: string;
 }
 
-export const MediaThumbnail: React.FC<MediaThumbnailProps> = ({
-  media,
-  className = "",
-}) => {
-  if (!media || media.length === 0) {
-    return null;
-  }
-
-  // For feed posts, show only the first 3 media items
-  const displayMedia = media.slice(0, 3);
-  const hasMore = media.length > 3;
+// Separate component to handle individual media items with state
+const MediaThumbnailItem: React.FC<{
+  item: {
+    url: string;
+    type: string;
+    displayName?: string;
+    thumbnailUrl?: string;
+  };
+}> = ({ item }) => {
+  const [isFallback, setIsFallback] = React.useState(false);
 
   const getFileTypeIcon = (type: string) => {
     switch (type) {
@@ -38,37 +37,47 @@ export const MediaThumbnail: React.FC<MediaThumbnailProps> = ({
   };
 
   return (
-    <div className={`flex gap-2 ${className}`}>
-      {displayMedia.map((item, index) => {
-        const [isFallback, setIsFallback] = useState(false);
+    <div className="relative w-16 h-16 rounded-md overflow-hidden bg-muted flex-shrink-0">
+      <MediaFallback
+        url={item.url}
+        type={item.type}
+        displayName={item.displayName}
+        thumbnailUrl={item.thumbnailUrl}
+        className="w-full h-full object-cover"
+        fallbackClassName="w-full h-full"
+        iconSize="md"
+        onFallback={setIsFallback}
+      />
 
-        return (
-          <div
-            key={index}
-            className="relative w-16 h-16 rounded-md overflow-hidden bg-muted flex-shrink-0"
-          >
-            <MediaFallback
-              url={item.url}
-              type={item.type}
-              displayName={item.displayName}
-              thumbnailUrl={item.thumbnailUrl}
-              className="w-full h-full object-cover"
-              fallbackClassName="w-full h-full"
-              iconSize="md"
-              onFallback={setIsFallback}
-            />
-
-            {/* File type icon overlay - hidden for fallback states */}
-            {!isFallback && (
-              <div className="absolute top-1 left-1 pointer-events-none">
-                <div className="bg-black/50 text-white p-0.5 rounded">
-                  {getFileTypeIcon(item.type)}
-                </div>
-              </div>
-            )}
+      {/* File type icon overlay - hidden for fallback states */}
+      {!isFallback && (
+        <div className="absolute top-1 left-1 pointer-events-none">
+          <div className="bg-black/50 text-white p-0.5 rounded">
+            {getFileTypeIcon(item.type)}
           </div>
-        );
-      })}
+        </div>
+      )}
+    </div>
+  );
+};
+
+export const MediaThumbnail: React.FC<MediaThumbnailProps> = ({
+  media,
+  className = "",
+}) => {
+  if (!media || media.length === 0) {
+    return null;
+  }
+
+  // For feed posts, show only the first 3 media items
+  const displayMedia = media.slice(0, 3);
+  const hasMore = media.length > 3;
+
+  return (
+    <div className={`flex gap-2 ${className}`}>
+      {displayMedia.map((item, index) => (
+        <MediaThumbnailItem key={index} item={item} />
+      ))}
       {hasMore && (
         <div className="w-16 h-16 rounded-md bg-muted flex items-center justify-center text-xs text-muted-foreground">
           +{media.length - 3}

--- a/frontend/src/components/create-task-modal.tsx
+++ b/frontend/src/components/create-task-modal.tsx
@@ -257,17 +257,17 @@ export function CreateTaskModal({
                 className="text-xs underline text-muted-foreground hover:text-foreground"
               >
                 {formData.instrument ? "Change" : "Select"}
-                {/* Hidden input for browser validation */}
-                <SecureInput
-                  type="text"
-                  value={formData.instrument}
-                  required
-                  tabIndex={-1}
-                  autoComplete="off"
-                  style={{ opacity: 0, width: "1px" }}
-                  onChange={() => {}}
-                />
               </button>
+              {/* Hidden input for browser validation - moved outside button to prevent layout interference */}
+              <SecureInput
+                type="text"
+                value={formData.instrument}
+                required
+                tabIndex={-1}
+                autoComplete="off"
+                style={{ opacity: 0, width: "1px" }}
+                onChange={() => {}}
+              />
             </div>
             <InstrumentModal
               isOpen={instrumentModalOpen}
@@ -323,17 +323,25 @@ export function CreateTaskModal({
             <label className="block text-sm font-medium text-foreground mb-2 text-left">
               Checklist
             </label>
+
             <div className="flex flex-row flex-nowrap gap-2 mb-3">
-              <SecureInput
-                type="text"
-                value={newChecklistItem}
-                onChange={(e) => setNewChecklistItem(e.target.value)}
-                onKeyPress={(e) =>
-                  e.key === "Enter" && (e.preventDefault(), addChecklistItem())
-                }
-                className="flex-1 text-left"
-                placeholder="Add checklist item"
-              />
+              <div className="flex-1 relative">
+                <SecureInput
+                  type="text"
+                  value={newChecklistItem}
+                  onChange={(e) => setNewChecklistItem(e.target.value)}
+                  onKeyPress={(e) =>
+                    e.key === "Enter" &&
+                    (e.preventDefault(), addChecklistItem())
+                  }
+                  className="w-full text-left pr-16"
+                  placeholder="Add checklist item"
+                  maxLength={600}
+                />
+                <div className="absolute right-2 top-1/2 transform -translate-y-1/2 text-xs text-muted-foreground">
+                  {newChecklistItem.length}/600
+                </div>
+              </div>
               <button
                 type="button"
                 onClick={addChecklistItem}
@@ -350,7 +358,7 @@ export function CreateTaskModal({
                     className="flex flex-row items-center gap-3 p-3 bg-muted/30 rounded-lg w-full min-w-0"
                   >
                     <div className="w-5 h-5 rounded border-2 border-muted-foreground/30 flex-shrink-0"></div>
-                    <span className="flex-1 min-w-0 text-sm text-foreground text-left break-words truncate">
+                    <span className="flex-1 min-w-0 text-sm text-foreground text-left break-words">
                       {item}
                     </span>
                     <button

--- a/frontend/src/components/filter-bar.test.tsx
+++ b/frontend/src/components/filter-bar.test.tsx
@@ -20,19 +20,22 @@ vi.mock("./ui/button", () => ({
     variant,
     className,
     onClick,
+    disabled,
     ...props
   }: {
     children: React.ReactNode;
     variant?: string;
     className?: string;
     onClick?: () => void;
+    disabled?: boolean;
     [key: string]: any;
   }) => (
     <button
       data-testid="button"
-      data-variant={variant}
+      data-variant={variant || "default"}
       className={className}
       onClick={onClick}
+      disabled={disabled}
       {...props}
     >
       {children}
@@ -293,7 +296,7 @@ describe("FilterBar", () => {
     );
   });
 
-  it("handles cancel", () => {
+  it("handles clear filters", () => {
     render(
       <FilterBar filters={defaultFilters} onFilterChange={mockOnFilterChange} />
     );
@@ -303,10 +306,71 @@ describe("FilterBar", () => {
 
     expect(screen.getByTestId("dialog")).toBeInTheDocument();
 
-    const cancelButton = screen.getByText("Cancel");
-    fireEvent.click(cancelButton);
+    const clearButton = screen.getByText("Clear");
+    // Initially, the user filter has one checked option, so Clear should be enabled
+    expect(clearButton).not.toBeDisabled();
 
-    expect(screen.queryByTestId("dialog")).not.toBeInTheDocument();
+    // Click clear to reset all options
+    fireEvent.click(clearButton);
+
+    // Verify all checkboxes are unchecked
+    const checkboxes = screen.getAllByTestId("checkbox");
+    checkboxes.forEach((checkbox) => {
+      expect(checkbox).not.toBeChecked();
+    });
+
+    // After clearing, no options are checked, so Clear should be disabled
+    expect(clearButton).toBeDisabled();
+  });
+
+  it("clear button is properly styled and positioned", () => {
+    render(
+      <FilterBar filters={defaultFilters} onFilterChange={mockOnFilterChange} />
+    );
+
+    const buttons = screen.getAllByTestId("button");
+    fireEvent.click(buttons[0]); // user filter
+
+    const clearButton = screen.getByText("Clear");
+    const applyButton = screen.getByText("Apply");
+
+    // Verify both buttons are present and styled correctly
+    expect(clearButton).toBeInTheDocument();
+    expect(applyButton).toBeInTheDocument();
+
+    // Verify clear button has outline variant (secondary styling)
+    expect(clearButton).toHaveAttribute("data-variant", "outline");
+
+    // Verify apply button has default variant (primary styling)
+    expect(applyButton).toHaveAttribute("data-variant", "default");
+  });
+
+  it("clear functionality works with multiple checked options", () => {
+    render(
+      <FilterBar filters={defaultFilters} onFilterChange={mockOnFilterChange} />
+    );
+
+    const buttons = screen.getAllByTestId("button");
+    fireEvent.click(buttons[0]); // user filter
+
+    const checkboxes = screen.getAllByTestId("checkbox");
+
+    // Check multiple options
+    fireEvent.click(checkboxes[0]);
+    fireEvent.click(checkboxes[1]);
+
+    const clearButton = screen.getByText("Clear");
+    expect(clearButton).not.toBeDisabled();
+
+    // Clear all options
+    fireEvent.click(clearButton);
+
+    // Verify all checkboxes are unchecked
+    checkboxes.forEach((checkbox) => {
+      expect(checkbox).not.toBeChecked();
+    });
+
+    expect(clearButton).toBeDisabled();
   });
 
   it("applies custom className", () => {

--- a/frontend/src/components/filter-bar.tsx
+++ b/frontend/src/components/filter-bar.tsx
@@ -118,6 +118,12 @@ export function FilterBar({
     handleModalClose();
   };
 
+  const handleClearFilters = () => {
+    setLocalOptions((prev) =>
+      prev.map((option) => ({ ...option, checked: false }))
+    );
+  };
+
   const filteredOptions = localOptions.filter((option) =>
     option.label.toLowerCase().includes(searchTerm.toLowerCase())
   );
@@ -308,8 +314,12 @@ export function FilterBar({
               )}
             </div>
             <div className="flex justify-end space-x-2">
-              <Button variant="outline" onClick={handleModalClose}>
-                Cancel
+              <Button
+                variant="outline"
+                onClick={handleClearFilters}
+                disabled={!localOptions.some((option) => option.checked)}
+              >
+                Clear
               </Button>
               <Button onClick={handleApplyFilters}>Apply</Button>
             </div>

--- a/frontend/src/components/layout/TopBar.test.tsx
+++ b/frontend/src/components/layout/TopBar.test.tsx
@@ -104,7 +104,7 @@ describe("TopBar", () => {
   it("displays navigation links", () => {
     renderTopBar();
 
-    expect(screen.getByTestId("nav-link-/")).toBeInTheDocument();
+    expect(screen.getByTestId("nav-link-/feed")).toBeInTheDocument();
     expect(screen.getByTestId("nav-link-/practice")).toBeInTheDocument();
     expect(screen.getByTestId("nav-link-/task-library")).toBeInTheDocument();
     expect(screen.getByTestId("nav-link-/growth")).toBeInTheDocument();

--- a/frontend/src/components/layout/TopBar.tsx
+++ b/frontend/src/components/layout/TopBar.tsx
@@ -46,7 +46,7 @@ export function TopBar() {
           )}
           <nav className="flex flex-col gap-2 mt-4">
             <NavLink
-              to="/"
+              to="/feed"
               className={({ isActive }) =>
                 `px-3 py-2 rounded-md transition-colors text-base font-medium ${
                   isActive

--- a/frontend/src/components/task-detail.tsx
+++ b/frontend/src/components/task-detail.tsx
@@ -149,7 +149,7 @@ export function TaskDetail({
                   className="flex flex-row items-center gap-3 p-3 bg-muted/30 rounded-lg w-full min-w-0"
                 >
                   <div className="w-5 h-5 rounded border-2 border-muted-foreground/30 flex-shrink-0"></div>
-                  <span className="flex-1 min-w-0 text-sm text-foreground text-left break-words truncate">
+                  <span className="flex-1 min-w-0 text-sm text-foreground text-left break-words">
                     {item}
                   </span>
                 </div>

--- a/frontend/src/config/api.ts
+++ b/frontend/src/config/api.ts
@@ -105,16 +105,16 @@ export const buildApiUrl = (endpoint: string): string => {
 };
 
 // Environment detection
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
+ 
 export const isDevelopment = (import.meta as any).env.DEV;
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
+ 
 export const isProduction = (import.meta as any).env.PROD;
 
 // Log configuration in development
 if (isDevelopment) {
   console.log("API Configuration:", {
     baseUrl: apiConfig.baseUrl,
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+     
     environment: (import.meta as any).env.MODE,
   });
 }

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -124,7 +124,7 @@ ReactDOM.createRoot(root).render(
                 index
                 element={
                   <Suspense fallback={<LoadingScreen />}>
-                    <Feed />
+                    <About />
                   </Suspense>
                 }
               />

--- a/frontend/src/pages/Feed.tsx
+++ b/frontend/src/pages/Feed.tsx
@@ -148,16 +148,34 @@ const Feed = () => {
       const userFilter = activeFilters.find((f) => f.type === "user");
 
       if (userFilter?.isSelected && userFilter.options) {
+        // Check if "Me" is selected
+        const meSelected = userFilter.options.some(
+          (option) => option.id === "me" && option.checked
+        );
+
+        // Get selected user IDs (excluding "following" and "me")
         const selectedUserIds = userFilter.options
-          .filter((option) => option.checked && option.id !== "following")
+          .filter(
+            (option) =>
+              option.checked && option.id !== "following" && option.id !== "me"
+          )
           .map((option) => option.id);
+
+        // Check if "Following" is selected
         const followingSelected = userFilter.options.some(
           (option) => option.id === "following" && option.checked
         );
+
         if (followingSelected) {
           params.append("following", "true");
         }
-        if (selectedUserIds.length > 0) {
+
+        // If "Me" is selected, add current user's ID to the users parameter
+        if (meSelected && user?.id) {
+          const allUserIds = [...selectedUserIds, String(user.id)];
+          params.append("users", allUserIds.join(","));
+        } else if (selectedUserIds.length > 0) {
+          // Only add users param if there are other selected users
           params.append("users", selectedUserIds.join(","));
         }
       }

--- a/frontend/src/pages/Growth/TotalStatsView.tsx
+++ b/frontend/src/pages/Growth/TotalStatsView.tsx
@@ -121,7 +121,7 @@ export const TotalStatsView: React.FC<TotalStatsViewProps> = ({
         )}
       </div>
       {/* Tag breakdown cards */}
-      <div className="flex flex-col gap-4">
+      <div className="flex flex-col gap-4 mb-8">
         {tagTotals.length > 0 ? (
           tagTotals.map((tag) => (
             <Card

--- a/frontend/src/pages/PostView.tsx
+++ b/frontend/src/pages/PostView.tsx
@@ -448,8 +448,14 @@ export const PostView: React.FC = () => {
       {/* Comments Modal/Drawer */}
       {showCommentModal && (
         <Section spacing="md">
-          <div className="fixed inset-0 bg-black/50 flex items-end justify-center z-50">
-            <div className="bg-background border-t border-border rounded-t-lg w-full h-[70vh] sm:h-[80vh] flex flex-col animate-in slide-in-from-bottom duration-300">
+          <div
+            className="fixed inset-0 bg-black/50 flex items-end justify-center z-50"
+            onClick={() => setShowCommentModal(false)}
+          >
+            <div
+              className="bg-background border-t border-border rounded-t-lg w-full h-[70vh] sm:h-[80vh] flex flex-col animate-in slide-in-from-bottom duration-300"
+              onClick={(e) => e.stopPropagation()}
+            >
               {/* Header */}
               <div className="flex items-center justify-between p-3 sm:p-4 border-b border-border">
                 <h3 className="text-base sm:text-lg font-semibold">

--- a/frontend/src/pages/Practice.tsx
+++ b/frontend/src/pages/Practice.tsx
@@ -379,7 +379,7 @@ const PracticeInner: React.FC<{ session: SessionContextValue }> = ({
       }
 
       toast.success(`Successful save! Routing to your posts...`);
-      await new Promise((resolve) => setTimeout(resolve, 2500)); // Pause so the user can read the toast before redirect
+      await new Promise((resolve) => setTimeout(resolve, 1200)); // Pause so the user can read the toast before redirect
 
       // Extract current instrument before clearing session data
       const instrumentLabels = ALL_INSTRUMENTS.map((i) => i.label);

--- a/frontend/src/pages/TaskLibrary.tsx
+++ b/frontend/src/pages/TaskLibrary.tsx
@@ -38,6 +38,7 @@ import { Toaster } from "@/components/ui/sonner";
 import { toast } from "sonner";
 import { usePageTracking } from "../hooks/useAnalytics";
 import { apiClient } from "../services/auth";
+import { useAuth } from "../components/auth/AuthProvider";
 
 const TaskLibrary: React.FC = () => {
   const [searchParams] = useSearchParams();
@@ -62,7 +63,7 @@ const TaskLibrary: React.FC = () => {
   const previousFilterState = useRef<string>("");
   const hasProcessedUrlParam = useRef(false);
   const shouldFetchAfterUrlParam = useRef(false);
-  // const { user } = useAuth();
+  const { user } = useAuth();
   const [userOptions, setUserOptions] = useState<FilterOption[]>([]);
 
   const [activeFilters, setActiveFilters] = useState<FilterState[]>(() => [
@@ -132,13 +133,26 @@ const TaskLibrary: React.FC = () => {
           .filter((option) => option.checked)
           .map((option) => option.label);
 
+        // Check if "Me" is selected and add current user's display name
+        const meSelected = userFilter.options.some(
+          (option) => option.id === "me" && option.checked
+        );
+
         // Check if "Following" is selected
         const followingSelected = selectedUsers.includes("Following");
+
         if (followingSelected) {
           params.append("following", "true");
         } else if (selectedUsers.length > 0) {
           // Only add users param if not using following filter
           params.append("users", selectedUsers.join(","));
+        }
+
+        // If "Me" is selected, add current user's display name to users param
+        if (meSelected && user?.displayName) {
+          const currentUsers = selectedUsers.filter((name) => name !== "Me");
+          const allUsers = [...currentUsers, user.displayName];
+          params.set("users", allUsers.join(","));
         }
       }
 


### PR DESCRIPTION
See commits.. 

- update for CRSF headers on media posts. adds graceful failover. 
- adds logic to clear filters (instead of cancel button)
- adds clickout from comments modal
- lessens the planned delay after saving session (to routing to feed) 
- route to About on login
- feed and task library filtering by "me" fixed
- implements character limit for checklist items, removes text cutoff, fix select/change instrument button styling
- adds margin to bottom of total stats page