### PR TITLE
feat: google branding - Make pages for Terms and Priv Policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,21 @@ All notable changes to Freequency v3 will be documented in this file.
 
 ## [Unreleased]
 
-## [3.0.2] - 2025-01-26
+## [3.0.3] - 2025-10-11
+
+### Added
+
+- For Google Auth requirements, formatted pages for Privacy Policy and Terms of Service
+
+### Changed
+
+- Removed modals from Login for Privacy Policy and Terms of Service
+
+### Fixed
+
+- N/A
+
+## [3.0.2] - 2025-10-3
 
 ### Added
 
@@ -18,7 +32,7 @@ All notable changes to Freequency v3 will be documented in this file.
 
 - Modals now auto-open when accessing direct URLs for better Google Branding compliance
 
-## [3.0.1] - 2025-01-26
+## [3.0.1] - 2025-9-28
 
 ### Added
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "v3_frontend",
   "private": true,
-  "version": "3.0.2",
+  "version": "3.0.3",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/public/legal/privacy.md
+++ b/frontend/public/legal/privacy.md
@@ -1,7 +1,7 @@
 # Privacy Policy
 
 **Effective Date:** 2025-08-09
-**Last Updated:** 2025-08-09
+**Last Updated:** 2025-10-08
 
 ## 1. Introduction
 
@@ -74,9 +74,200 @@ By using our Service, you consent to the data practices described in this Privac
 - User behavior leading to errors
 - Technical performance data
 
-## 3. How We Use Your Information
+## 3. Google User Data - Specific Disclosures
 
-### 3.1 Primary Service Functions
+We use Google OAuth 2.0 for authentication. This section provides specific information about how we access, use, store, share, and protect Google user data.
+
+### 3.1 Google Data Accessed
+
+When you authenticate with Google, we request and access the following specific types of Google user data:
+
+- **Email Address:** Your primary Google account email address
+- **Profile Information:**
+  - Full name (given name and family name)
+  - Profile picture URL
+  - Google User ID (for authentication purposes)
+- **Basic Account Information:** Used to create and maintain your Freequency account
+
+**Scope of Access:**
+
+- We only request the minimum necessary permissions (OpenID, email, and profile)
+- We do NOT access any other Google services (Gmail, Drive, Calendar, etc.)
+- We do NOT access your Google contacts, files, or other personal data stored in Google services
+- Authentication is handled entirely through Google's secure OAuth 2.0 protocol
+
+### 3.2 How We Use Google User Data
+
+We use the Google user data we collect for the following specific purposes:
+
+**Account Creation and Authentication:**
+
+- Creating your Freequency user account
+- Authenticating your identity when you log in
+- Maintaining your login session
+- Verifying your identity for account security
+
+**Profile Display:**
+
+- Displaying your name and profile picture on your Freequency profile
+- Showing your name and picture on posts, comments, and interactions
+- Allowing other users to identify and connect with you
+
+**Communication:**
+
+- Sending important account-related notifications (if enabled)
+- Contacting you about security issues or Terms of Service violations
+- Responding to support requests you submit
+
+**Data Processing:**
+
+- All Google user data is processed on secure servers
+- Data is used only for the purposes described in this policy
+- We do NOT use Google user data for advertising or marketing purposes
+- We do NOT analyze Google user data for purposes unrelated to service provision
+
+### 3.3 Google Data Sharing with Third Parties
+
+**We do NOT sell or rent your Google user data to any third parties.**
+
+We may share limited Google user data with the following service providers solely for service operation:
+
+**Amazon Web Services (AWS):**
+
+- Purpose: Secure data storage and hosting
+- Data Shared: Encrypted user profile information (name, email, profile picture)
+- Use: Storing your account data in our secure database
+- Protection: Data is encrypted at rest and in transit
+- Contract: AWS is bound by data processing agreements
+
+**Sentry (Error Monitoring):**
+
+- Purpose: Technical error monitoring and debugging
+- Data Shared: May include email address in error logs (anonymized when possible)
+- Use: Identifying and fixing technical issues that affect your account
+- Protection: Data is minimized and anonymized where possible
+- Contract: Sentry is bound by data processing agreements
+
+**No Other Third-Party Sharing:**
+
+- We do NOT share your Google user data with advertisers
+- We do NOT use your Google user data for marketing purposes
+- We do NOT share your data with social media platforms
+- We do NOT combine your Google data with data from other sources for profiling
+
+**Legal Exceptions:**
+We may disclose Google user data only when legally required:
+
+- To comply with valid legal process (subpoenas, court orders)
+- To protect our legal rights or the safety of our users
+- In the event of a merger or acquisition (with the same privacy protections)
+
+### 3.4 Google Data Storage and Protection
+
+**Storage Infrastructure:**
+
+- **Location:** Google user data is stored in secure AWS (Amazon Web Services) cloud infrastructure
+- **Encryption at Rest:** Data is encrypted using AWS server-side encryption
+- **Encryption in Transit:** All data transmission uses secure HTTPS/SSL connections
+- **Database Security:** PostgreSQL database with restricted access and secure connections
+- **Access Controls:** Restricted access to production systems on a need-to-know basis
+- **Geographic Location:** Data is stored in secure cloud data centers
+
+**Security Measures:**
+
+- **Authentication Security:**
+
+  - No passwords stored (authentication handled by Google OAuth)
+  - Secure session tokens with automatic expiration
+  - CSRF protection on all authenticated requests
+  - Rate limiting to prevent brute force attacks
+
+- **Access Limitation:**
+
+  - Principle of least privilege for all system access
+  - Only authorized personnel can access production data
+  - Production access is monitored and controlled
+
+- **Data Protection:**
+  - Regular automated backups
+  - Error monitoring and alerting with Sentry
+  - Regular security updates and patches applied
+
+**Compliance:**
+
+- We follow industry best practices for data security
+- Our practices align with OWASP security guidelines
+- We maintain security measures compliant with GDPR and CCPA requirements
+
+### 3.5 Google Data Retention and Deletion
+
+**Data Retention Policy:**
+
+**Active Accounts:**
+
+- Google user data (email, name, profile picture) is retained while your account is active
+- This data is necessary for account authentication and service provision
+- You can update your profile information at any time through account settings
+
+**Account Deletion:**
+When you delete your Freequency account, the following process occurs:
+
+1. **Immediate Actions (Within 24 hours):**
+
+   - Your account is deactivated and you can no longer log in
+   - Your profile becomes inaccessible to other users
+   - Your name and profile picture are removed from public view
+
+2. **Complete Deletion (Within 30 days):**
+
+   - All Google user data (email, name, profile picture) is permanently deleted from our primary database
+   - All associated practice sessions, posts, and content are deleted
+   - Your data is removed from all active systems
+
+3. **Backup Deletion (Within 90 days):**
+   - Data is purged from encrypted backup systems
+   - No recoverable copies remain after this period
+
+**Legal Retention Requirements:**
+
+- Some data may be retained longer if required by law (e.g., for tax purposes, legal disputes)
+- Retention for legal purposes is limited to the minimum required by law
+- Such data is securely isolated and not used for any other purpose
+
+**How to Request Deletion:**
+
+To delete your account and all associated Google user data:
+
+**Email Request:**
+
+- Send an email to: freequency.app@gmail.com
+- Subject: "Account Deletion Request"
+- Include: The email address associated with your account
+- We will process your request within 5 business days
+- You will receive confirmation when deletion is complete
+
+**Data Portability Before Deletion:**
+
+- Before requesting deletion, you can request a copy of your data
+- Email freequency.app@gmail.com with subject "Data Export Request"
+- We will provide your data in a portable format (JSON/CSV)
+- Data export is provided within 30 days
+
+**Verification:**
+
+- For security purposes, we may verify your identity before processing deletion requests
+- Verification is typically done via your registered Google account email
+
+**Right to Deletion:**
+
+- You can request deletion at any time for any reason
+- Deletion is permanent and cannot be undone
+- After deletion, we cannot recover your account or data
+- We will not charge any fee for data deletion
+
+## 4. How We Use Your Information (General)
+
+### 4.1 Primary Service Functions
 
 - **Account Management:** Create and maintain your user account
 - **Content Display:** Show your practice sessions to other users
@@ -84,28 +275,28 @@ By using our Service, you consent to the data practices described in this Privac
 - **Progress Tracking:** Store and display your practice statistics and goals
 - **Personalization:** Customize your experience and content recommendations
 
-### 3.2 Service Improvement
+### 4.2 Service Improvement
 
 - **Analytics:** Understand how users interact with our platform
 - **Performance Monitoring:** Identify and fix technical issues
 - **Feature Development:** Develop new features based on usage patterns
 - **Quality Assurance:** Ensure platform stability and security
 
-### 3.3 Communication
+### 4.3 Communication
 
 - **Service Updates:** Notify you of important changes or updates
 - **Support:** Respond to your questions and support requests
 - **Security:** Alert you to security issues or suspicious activity
 
-### 3.4 Legal and Safety
+### 4.4 Legal and Safety
 
 - **Compliance:** Comply with legal obligations and regulations
 - **Safety:** Protect against harmful or illegal activity
 - **Dispute Resolution:** Resolve conflicts and enforce our Terms of Service
 
-## 4. Information Sharing and Disclosure
+## 5. Information Sharing and Disclosure
 
-### 4.1 Public Information
+### 5.1 Public Information
 
 The following information is publicly visible to other users:
 
@@ -115,7 +306,7 @@ The following information is publicly visible to other users:
 - Comments and Gas Ups on public posts
 - Practice statistics and achievements (if you choose to share them)
 
-### 4.2 Third-Party Service Providers
+### 5.2 Third-Party Service Providers
 
 **Google Services:**
 
@@ -143,7 +334,7 @@ The following information is publicly visible to other users:
 - Used solely for technical troubleshooting
 - Data is anonymized when possible
 
-### 4.3 Legal Disclosures
+### 5.3 Legal Disclosures
 
 We may disclose your information when required by law or to:
 
@@ -153,13 +344,13 @@ We may disclose your information when required by law or to:
 - Investigate potential violations of our Terms of Service
 - Prevent illegal activity or harm
 
-### 4.4 Business Transfers
+### 5.4 Business Transfers
 
 In the event of a merger, acquisition, or sale of assets, your information may be transferred to the new entity, subject to the same privacy protections.
 
-## 5. Data Security
+## 6. Data Security
 
-### 5.1 Security Measures
+### 6.1 Security Measures
 
 We implement industry-standard security measures to protect your information:
 
@@ -169,43 +360,43 @@ We implement industry-standard security measures to protect your information:
 - **Monitoring:** Continuous monitoring for security threats
 - **Regular Updates:** Regular security updates and patches
 
-### 5.2 Data Storage
+### 6.2 Data Storage
 
 - **Location:** Data is stored in secure cloud infrastructure (AWS)
 - **Retention:** We retain data only as long as necessary for service provision
 - **Backups:** Secure backups are maintained for data recovery purposes
 
-### 5.3 Limitations
+### 6.3 Limitations
 
 While we implement strong security measures, no system is completely secure. We cannot guarantee absolute security of your information.
 
-## 6. Your Privacy Rights
+## 7. Your Privacy Rights
 
-### 6.1 Access and Portability
+### 7.1 Access and Portability
 
 - **View Data:** Access your personal information through your account settings
 - **Export Data:** Request a copy of your data in a portable format
 - **Data Summary:** Receive a summary of data we collect about you
 
-### 6.2 Correction and Updates
+### 7.2 Correction and Updates
 
 - **Profile Updates:** Modify your profile information at any time
 - **Content Management:** Edit or delete your practice sessions and content
 - **Settings Control:** Adjust privacy settings and preferences
 
-### 6.3 Deletion Rights
+### 7.3 Deletion Rights
 
 - **Account Deletion:** Delete your account and associated data
 - **Content Removal:** Remove specific posts or media files
 - **Right to be Forgotten:** Request complete removal of your information (subject to legal requirements)
 
-### 6.4 Data Processing Control
+### 7.4 Data Processing Control
 
 - **Opt-Out:** Opt out of analytics tracking and non-essential data processing
 - **Communication Preferences:** Control what communications you receive
 - **Visibility Settings:** Control who can see your content and profile
 
-### 6.5 Regional Rights
+### 7.5 Regional Rights
 
 **For EU Users (GDPR):**
 
@@ -224,37 +415,37 @@ While we implement strong security measures, no system is completely secure. We 
 - Right to opt-out of sale of personal information (**we do not sell data - we are non-commercial**)
 - Right to non-discrimination for exercising privacy rights
 
-## 7. Children's Privacy
+## 8. Children's Privacy
 
-### 7.1 Age Requirements
+### 8.1 Age Requirements
 
 - Our Service is intended for users 13 years of age and older
 - We do not knowingly collect personal information from children under 13
 - If we discover we have collected information from a child under 13, we will delete it immediately
 
-### 7.2 Parental Controls
+### 8.2 Parental Controls
 
 - Parents may request deletion of their child's account
 - We encourage parents to monitor their children's online activities
 - Contact us if you believe a child under 13 has created an account
 
-## 8. International Data Transfers
+## 9. International Data Transfers
 
-### 8.1 Data Location
+### 9.1 Data Location
 
 - Your data may be processed and stored in countries other than your own
 - We ensure adequate protection for international data transfers
 - We comply with applicable data protection laws for cross-border transfers
 
-### 8.2 Protection Measures
+### 9.2 Protection Measures
 
 - Standard contractual clauses with service providers
 - Adequacy decisions for certain countries
 - Additional safeguards where required by law
 
-## 9. Cookies and Tracking Technologies
+## 10. Cookies and Tracking Technologies
 
-### 9.1 Types of Cookies
+### 10.1 Types of Cookies
 
 **Essential Cookies:**
 
@@ -274,7 +465,7 @@ While we implement strong security measures, no system is completely secure. We 
 - Feature customization
 - Enhanced user experience
 
-### 9.2 Cookie Control
+### 10.2 Cookie Control
 
 - **Browser Settings:** Disable cookies through browser settings
 - **Opt-Out Tools:** Use Google Analytics opt-out browser add-on
@@ -282,52 +473,52 @@ While we implement strong security measures, no system is completely secure. We 
 
 Note: Disabling essential cookies may limit platform functionality.
 
-## 10. Data Retention
+## 11. Data Retention
 
-### 10.1 Retention Periods
+### 11.1 Retention Periods
 
 - **Account Data:** Retained while your account is active
 - **Practice Content:** Retained until you delete it or close your account
 - **Analytics Data:** Anonymized data may be retained for business insights
 - **Legal Requirements:** Some data may be retained to comply with legal obligations
 
-### 10.2 Deletion Process
+### 11.2 Deletion Process
 
 - **Account Deletion:** Most data is deleted within 30 days of account closure
 - **Content Removal:** Deleted content is removed from public view immediately
 - **Backup Deletion:** Data in backups is deleted according to our retention schedule
 - **Legal Hold:** Some data may be preserved if required for legal proceedings
 
-## 11. Changes to This Privacy Policy
+## 12. Changes to This Privacy Policy
 
-### 11.1 Updates
+### 12.1 Updates
 
 - We may update this Privacy Policy to reflect changes in our practices or legal requirements
 - Material changes will be announced through the Service or via email
 - Continued use after changes constitutes acceptance of the updated policy
 
-### 11.2 Notification
+### 12.2 Notification
 
 - **Advance Notice:** We provide at least 30 days notice of material changes
 - **Effective Date:** Changes take effect on the date specified in the updated policy
 - **Review Opportunity:** You can review changes before they take effect
 
-## 12. Contact Information
+## 13. Contact Information
 
-### 12.1 Privacy Questions
+### 13.1 Privacy Questions
 
 For questions about this Privacy Policy or our data practices:
 
 - **Email:** freequency.app@gmail.com
 - **Legal Team:** freequency.app@gmail.com
 
-### 12.2 Data Protection Officer
+### 13.2 Data Protection Officer
 
 If required by law, our Data Protection Officer can be reached at:
 
 - **Email:** freequency.app@gmail.com
 
-### 12.3 Response Time
+### 13.3 Response Time
 
 We will respond to privacy-related inquiries within:
 
@@ -335,24 +526,24 @@ We will respond to privacy-related inquiries within:
 - **Data Subject Requests:** 30 days (as required by law)
 - **Urgent Security Issues:** Within 24 hours
 
-## 13. Specific Jurisdictional Information
+## 14. Specific Jurisdictional Information
 
-### 13.1 European Union
+### 14.1 European Union
 
 - **Legal Basis:** We process data based on consent, legitimate interests, and legal obligations
 - **Data Protection Authority:** You may file complaints with your local data protection authority
 
-### 13.2 California
+### 14.2 California
 
 - **CCPA Compliance:** We comply with the California Consumer Privacy Act
 - **Do Not Sell:** We do not sell personal information (we are a non-commercial platform)
 - **Authorized Agent:** You may designate an authorized agent to make requests on your behalf
 
-### 13.3 Other Jurisdictions
+### 14.3 Other Jurisdictions
 
 We comply with applicable privacy laws in all jurisdictions where we operate. Contact us for specific information about your local privacy rights.
 
 ---
 
-**Last Review Date:** 2025-08-09
+**Last Review Date:** 2025-10-08
 **Next Scheduled Review:** 2026-08-09

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -84,6 +84,8 @@ const PostView = lazy(() =>
   import("./pages/PostView").then((m) => ({ default: m.PostView }))
 );
 const About = lazy(() => import("./pages/About"));
+const TermsOfService = lazy(() => import("./pages/TermsOfService"));
+const PrivacyPolicy = lazy(() => import("./pages/PrivacyPolicy"));
 const SessionProvider = lazy(() =>
   import("./components/SessionContext").then((m) => ({
     default: m.SessionProvider,
@@ -106,8 +108,22 @@ ReactDOM.createRoot(root).render(
           <Routes>
             {/* Public routes */}
             <Route path="/login" element={<Login />} />
-            <Route path="/login/termsofservice" element={<Login />} />
-            <Route path="/login/privacypolicy" element={<Login />} />
+            <Route
+              path="/legal/terms"
+              element={
+                <Suspense fallback={<LoadingScreen />}>
+                  <TermsOfService />
+                </Suspense>
+              }
+            />
+            <Route
+              path="/legal/privacy"
+              element={
+                <Suspense fallback={<LoadingScreen />}>
+                  <PrivacyPolicy />
+                </Suspense>
+              }
+            />
 
             {/* Protected routes */}
             <Route

--- a/frontend/src/pages/Login.tsx
+++ b/frontend/src/pages/Login.tsx
@@ -1,5 +1,5 @@
-import React, { useEffect, useState } from "react";
-import { useLocation, useNavigate } from "react-router";
+import React, { useState } from "react";
+import { useNavigate } from "react-router";
 import { useAuth } from "../components/auth/AuthProvider";
 import { Button } from "../components/ui/button";
 import { CardContent, CardHeader } from "../components/ui/card";
@@ -70,12 +70,8 @@ const aboutSections = [
 
 const Login: React.FC = () => {
   const { login } = useAuth();
-  const location = useLocation();
   const navigate = useNavigate();
-  const [modal, setModal] = useState<null | "terms" | "privacy" | "about">(
-    null
-  );
-  const [docText, setDocText] = useState<string>("");
+  const [showAbout, setShowAbout] = useState(false);
 
   // Track page view for analytics
   usePageTracking("Login");
@@ -87,55 +83,6 @@ const Login: React.FC = () => {
     } else {
       login();
     }
-  };
-
-  // Handle URL-based modal opening
-  useEffect(() => {
-    const path = location.pathname;
-    if (path === "/login/termsofservice") {
-      setModal("terms");
-    } else if (path === "/login/privacypolicy") {
-      setModal("privacy");
-    } else {
-      setModal(null);
-    }
-  }, [location.pathname]);
-
-  useEffect(() => {
-    const loadDoc = async () => {
-      if (!modal) return;
-      const path = modal === "terms" ? "/legal/terms.md" : "/legal/privacy.md";
-      try {
-        const resp = await fetch(path, { cache: "no-store" });
-        const text = await resp.text();
-        setDocText(text);
-      } catch {
-        setDocText("Failed to load document. Please try again later.");
-      }
-    };
-    loadDoc();
-  }, [modal]);
-
-  const renderMarkdown = (md: string) => {
-    // Minimal markdown to HTML conversion for headings/paragraphs/lists.
-    // This keeps bundle small and avoids adding a new dependency.
-    let html = md
-      .replace(/^###\s(.+)$/gim, "<h3>$1</h3>")
-      .replace(/^##\s(.+)$/gim, "<h2>$1</h2>")
-      .replace(/^#\s(.+)$/gim, "<h1>$1</h1>")
-      .replace(/^-\s(.+)$/gim, "<li>$1</li>")
-      .replace(/^\*\*(.+)\*\*/gim, "<strong>$1</strong>")
-      .replace(/\*\*(.+?)\*\*/gim, "<strong>$1</strong>")
-      .replace(/\*(.+?)\*/gim, "<em>$1</em>")
-      .replace(/\n\n/g, "<br/><br/>");
-
-    // Wrap loose list items into <ul>
-    html = html.replace(
-      /(<li>[^<]*<\/li>\s*)+/gim,
-      (match) => `<ul>${match}</ul>`
-    );
-
-    return { __html: html };
   };
 
   return (
@@ -157,7 +104,7 @@ const Login: React.FC = () => {
         </CardHeader>
         <CardContent className="space-y-4">
           <Button
-            onClick={() => setModal("about")}
+            onClick={() => setShowAbout(true)}
             className="w-full bg-white text-gray-700 border border-gray-300 hover:bg-gray-50"
             variant="outline"
           >
@@ -193,22 +140,22 @@ const Login: React.FC = () => {
             <p>By continuing, you agree to our</p>
             <p>
               <a
-                href="/login/termsofservice"
+                href="/legal/terms"
                 className="text-primary hover:underline cursor-pointer"
                 onClick={(e) => {
                   e.preventDefault();
-                  navigate("/login/termsofservice");
+                  navigate("/legal/terms");
                 }}
               >
                 Terms of Service
               </a>{" "}
               and{" "}
               <a
-                href="/login/privacypolicy"
+                href="/legal/privacy"
                 className="text-primary hover:underline cursor-pointer"
                 onClick={(e) => {
                   e.preventDefault();
-                  navigate("/login/privacypolicy");
+                  navigate("/legal/privacy");
                 }}
               >
                 Privacy Policy
@@ -216,46 +163,26 @@ const Login: React.FC = () => {
             </p>
           </div>
         </CardContent>
-        <Dialog
-          open={modal !== null}
-          onOpenChange={(open) => {
-            if (!open) {
-              // Navigate back to /login when modal is closed
-              navigate("/login");
-            }
-          }}
-        >
+        <Dialog open={showAbout} onOpenChange={setShowAbout}>
           <DialogContent className="max-w-lg">
             <DialogHeader>
-              <DialogTitle>
-                {modal === "terms"
-                  ? "Terms of Service"
-                  : modal === "privacy"
-                  ? "Privacy Policy"
-                  : "Welcome!"}
-              </DialogTitle>
+              <DialogTitle>Welcome!</DialogTitle>
             </DialogHeader>
             <div className="mt-2 max-h-[70vh] overflow-y-auto pr-2">
-              {modal === "about" ? (
-                <div className="space-y-6">
-                  {aboutSections.map((section) => (
-                    <div key={section.title} className="space-y-2">
-                      <h3 className="text-lg font-semibold text-primary">
-                        {section.title}
-                      </h3>
-                      <p className="text-base">{section.content}</p>
-                    </div>
-                  ))}
-                  <p className="text-muted-foreground mt-8 text-sm text-center">
-                    Version {packageJson.version} &mdash; &copy;{" "}
-                    {new Date().getFullYear()} Freequency
-                  </p>
-                </div>
-              ) : (
-                <div className="prose max-w-none text-left text-sm">
-                  <div dangerouslySetInnerHTML={renderMarkdown(docText)} />
-                </div>
-              )}
+              <div className="space-y-6">
+                {aboutSections.map((section) => (
+                  <div key={section.title} className="space-y-2">
+                    <h3 className="text-lg font-semibold text-primary">
+                      {section.title}
+                    </h3>
+                    <p className="text-base">{section.content}</p>
+                  </div>
+                ))}
+                <p className="text-muted-foreground mt-8 text-sm text-center">
+                  Version {packageJson.version} &mdash; &copy;{" "}
+                  {new Date().getFullYear()} Freequency
+                </p>
+              </div>
             </div>
           </DialogContent>
         </Dialog>

--- a/frontend/src/pages/PrivacyPolicy.tsx
+++ b/frontend/src/pages/PrivacyPolicy.tsx
@@ -1,0 +1,85 @@
+import React, { useEffect, useState } from "react";
+import { useNavigate } from "react-router";
+import { Container } from "../components/layout/Container";
+import { Button } from "../components/ui/button";
+import { CardContent, CardHeader } from "../components/ui/card";
+import { ChevronLeft } from "lucide-react";
+import { usePageTracking } from "../hooks/useAnalytics";
+
+const PrivacyPolicy: React.FC = () => {
+  const navigate = useNavigate();
+  const [docText, setDocText] = useState<string>("");
+  const [isLoading, setIsLoading] = useState(true);
+
+  // Track page view for analytics
+  usePageTracking("Privacy Policy");
+
+  useEffect(() => {
+    const loadDoc = async () => {
+      try {
+        const resp = await fetch("/legal/privacy.md", { cache: "no-store" });
+        const text = await resp.text();
+        setDocText(text);
+      } catch {
+        setDocText("Failed to load document. Please try again later.");
+      } finally {
+        setIsLoading(false);
+      }
+    };
+    loadDoc();
+  }, []);
+
+  const renderMarkdown = (md: string) => {
+    // Minimal markdown to HTML conversion for headings/paragraphs/lists.
+    // This keeps bundle small and avoids adding a new dependency.
+    let html = md
+      .replace(/^###\s(.+)$/gim, "<h3>$1</h3>")
+      .replace(/^##\s(.+)$/gim, "<h2>$1</h2>")
+      .replace(/^#\s(.+)$/gim, "<h1>$1</h1>")
+      .replace(/^-\s(.+)$/gim, "<li>$1</li>")
+      .replace(/^\*\*(.+)\*\*/gim, "<strong>$1</strong>")
+      .replace(/\*\*(.+?)\*\*/gim, "<strong>$1</strong>")
+      .replace(/\*(.+?)\*/gim, "<em>$1</em>")
+      .replace(/\n\n/g, "<br/><br/>");
+
+    // Wrap loose list items into <ul>
+    html = html.replace(
+      /(<li>[^<]*<\/li>\s*)+/gim,
+      (match) => `<ul>${match}</ul>`
+    );
+
+    return { __html: html };
+  };
+
+  return (
+    <div className="min-h-screen w-full flex flex-col items-center p-4 bg-background">
+      <Container size="lg" className="py-8">
+        <CardHeader className="space-y-4">
+          <div className="flex items-center gap-4">
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={() => navigate("/login")}
+              className="flex items-center gap-2"
+            >
+              <ChevronLeft className="h-4 w-4" />
+              Back to Login
+            </Button>
+          </div>
+          <h1 className="text-3xl font-bold text-center">Privacy Policy</h1>
+        </CardHeader>
+        <CardContent className="mt-4">
+          {isLoading ? (
+            <div className="text-center text-muted-foreground">Loading...</div>
+          ) : (
+            <div className="prose prose-sm max-w-none text-left">
+              <div dangerouslySetInnerHTML={renderMarkdown(docText)} />
+            </div>
+          )}
+        </CardContent>
+      </Container>
+    </div>
+  );
+};
+
+export default PrivacyPolicy;

--- a/frontend/src/pages/TermsOfService.tsx
+++ b/frontend/src/pages/TermsOfService.tsx
@@ -1,0 +1,85 @@
+import React, { useEffect, useState } from "react";
+import { useNavigate } from "react-router";
+import { Container } from "../components/layout/Container";
+import { Button } from "../components/ui/button";
+import { CardContent, CardHeader } from "../components/ui/card";
+import { ChevronLeft } from "lucide-react";
+import { usePageTracking } from "../hooks/useAnalytics";
+
+const TermsOfService: React.FC = () => {
+  const navigate = useNavigate();
+  const [docText, setDocText] = useState<string>("");
+  const [isLoading, setIsLoading] = useState(true);
+
+  // Track page view for analytics
+  usePageTracking("Terms of Service");
+
+  useEffect(() => {
+    const loadDoc = async () => {
+      try {
+        const resp = await fetch("/legal/terms.md", { cache: "no-store" });
+        const text = await resp.text();
+        setDocText(text);
+      } catch {
+        setDocText("Failed to load document. Please try again later.");
+      } finally {
+        setIsLoading(false);
+      }
+    };
+    loadDoc();
+  }, []);
+
+  const renderMarkdown = (md: string) => {
+    // Minimal markdown to HTML conversion for headings/paragraphs/lists.
+    // This keeps bundle small and avoids adding a new dependency.
+    let html = md
+      .replace(/^###\s(.+)$/gim, "<h3>$1</h3>")
+      .replace(/^##\s(.+)$/gim, "<h2>$1</h2>")
+      .replace(/^#\s(.+)$/gim, "<h1>$1</h1>")
+      .replace(/^-\s(.+)$/gim, "<li>$1</li>")
+      .replace(/^\*\*(.+)\*\*/gim, "<strong>$1</strong>")
+      .replace(/\*\*(.+?)\*\*/gim, "<strong>$1</strong>")
+      .replace(/\*(.+?)\*/gim, "<em>$1</em>")
+      .replace(/\n\n/g, "<br/><br/>");
+
+    // Wrap loose list items into <ul>
+    html = html.replace(
+      /(<li>[^<]*<\/li>\s*)+/gim,
+      (match) => `<ul>${match}</ul>`
+    );
+
+    return { __html: html };
+  };
+
+  return (
+    <div className="min-h-screen w-full flex flex-col items-center p-4 bg-background">
+      <Container size="lg" className="py-8">
+        <CardHeader className="space-y-4">
+          <div className="flex items-center gap-4">
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={() => navigate("/login")}
+              className="flex items-center gap-2"
+            >
+              <ChevronLeft className="h-4 w-4" />
+              Back to Login
+            </Button>
+          </div>
+          <h1 className="text-3xl font-bold text-center">Terms of Service</h1>
+        </CardHeader>
+        <CardContent className="mt-4">
+          {isLoading ? (
+            <div className="text-center text-muted-foreground">Loading...</div>
+          ) : (
+            <div className="prose prose-sm max-w-none text-left">
+              <div dangerouslySetInnerHTML={renderMarkdown(docText)} />
+            </div>
+          )}
+        </CardContent>
+      </Container>
+    </div>
+  );
+};
+
+export default TermsOfService;


### PR DESCRIPTION
Google requires the terms and priv pol be reachable separately from your project home. So /login/terms etc. was not acceptable. Switched over to /legal . 
Also need to update the language in my Priv Pol but this brought up the fact that users cannot delete their profiles at the moment. This is a necessity, so I am planning to build that feature in a separate branch and then further update the privacy policy language to reflect that.